### PR TITLE
Replaced BAUtil class with a category on UIColor

### DIFF
--- a/Example/BAFluidView/BAViewController.m
+++ b/Example/BAFluidView/BAViewController.m
@@ -22,7 +22,7 @@
 
 #import "BAViewController.h"
 #import "BAFluidView.h"
-#import "BAUtil.h"
+#import "UIColor+ColorWithHex.h"
 
 @interface BAViewController ()
 
@@ -189,7 +189,7 @@
     //resetting a gradient layer causes the iphone6 simulator to fail (weird bug)
     CAGradientLayer *tempLayer = [CAGradientLayer layer];
     tempLayer.frame = self.view.bounds;
-    tempLayer.colors = @[(id)[BAUtil UIColorFromHex:0x53cf84].CGColor,(id)[BAUtil UIColorFromHex:0x53cf84].CGColor, (id)[BAUtil UIColorFromHex:0x2aa581].CGColor, (id)[BAUtil UIColorFromHex:0x1b9680].CGColor];
+    tempLayer.colors = @[(id)[UIColor colorWithHex:0x53cf84].CGColor,(id)[UIColor colorWithHex:0x53cf84].CGColor, (id)[UIColor colorWithHex:0x2aa581].CGColor, (id)[UIColor colorWithHex:0x1b9680].CGColor];
     tempLayer.locations = @[[NSNumber numberWithFloat:0.0f], [NSNumber numberWithFloat:0.5f],[NSNumber numberWithFloat:0.8f], [NSNumber numberWithFloat:1.0f]];
     tempLayer.startPoint = CGPointMake(0, 0);
     tempLayer.endPoint = CGPointMake(1, 1);
@@ -253,7 +253,7 @@
 
             fluidView = [[BAFluidView alloc] initWithFrame:self.view.frame startElevation:@0.3];
             
-            fluidView.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+            fluidView.fillColor = [UIColor colorWithHex:0x397ebe];
             [fluidView fillTo:@0.9];
             [fluidView startAnimation];
             
@@ -263,7 +263,7 @@
             [maskingLayer setContents:(id)[maskingImage CGImage]];
             [fluidView.layer setMask:maskingLayer];
 
-            [self changeTitleColor:[BAUtil UIColorFromHex:0x2e353d]];
+            [self changeTitleColor:[UIColor colorWithHex:0x2e353d]];
             
             return fluidView;
         }
@@ -271,7 +271,7 @@
         case 1://example with a fill of the screen
         {
             fluidView = [[BAFluidView alloc] initWithFrame:self.view.frame startElevation:@0.0];
-            fluidView.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+            fluidView.fillColor = [UIColor colorWithHex:0x397ebe];
             [fluidView fillTo:@1.0];
             [fluidView startAnimation];
             [self changeTitleColor:[UIColor whiteColor]];
@@ -282,7 +282,7 @@
         {
             fluidView = [[BAFluidView alloc] initWithFrame:self.view.frame startElevation:@0.5];
             fluidView.strokeColor = [UIColor whiteColor];
-            fluidView.fillColor = [BAUtil UIColorFromHex:0x2e353d];
+            fluidView.fillColor = [UIColor colorWithHex:0x2e353d];
             [fluidView keepStationary];
             [fluidView startAnimation];
             [self changeTitleColor:[UIColor whiteColor]];
@@ -296,7 +296,7 @@
             fluidView.strokeColor = [UIColor whiteColor];
             [fluidView keepStationary];
             [fluidView startAnimation];
-            [self changeTitleColor:[BAUtil UIColorFromHex:0x2e353d]];
+            [self changeTitleColor:[UIColor colorWithHex:0x2e353d]];
             return fluidView;
         }
         default:

--- a/Example/Pods/Headers/Public/BAFluidView/BAUtil.h
+++ b/Example/Pods/Headers/Public/BAFluidView/BAUtil.h
@@ -1,1 +1,0 @@
-../../../../../Pod/Classes/BAUtil.h

--- a/Example/Pods/Headers/Public/BAFluidView/UIColor+ColorWithHex.h
+++ b/Example/Pods/Headers/Public/BAFluidView/UIColor+ColorWithHex.h
@@ -1,0 +1,1 @@
+../../../../../Pod/Classes/UIColor+ColorWithHex.h

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,1869 +1,858 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>00C3CA131475187322B83C7A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-Tests-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>00CC2A2D7A67ACD10BDDBB81</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3692AD5806DB929799132A0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>02A79ABE3AEC3030271BEAA7</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Tests-BAFluidView.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>0345735DA555D09D8A059AB8</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-Tests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>04CF807E1DAA4B60B1116A01</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>9CE2A8D2231D79E6FA27D05C</string>
-			<key>buildPhases</key>
-			<array>
-				<string>F53AB24F68EF8C8E93664481</string>
-				<string>96010581A69760ED18C74D65</string>
-				<string>794E77DAB7124ADC74A0BE01</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BAFluidView</string>
-			<key>productName</key>
-			<string>BAFluidView</string>
-			<key>productReference</key>
-			<string>F8B60D316F015FA1D9CB98BF</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle</string>
-		</dict>
-		<key>07116E5EC71F54CAEADBEA16</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>234920B533770B45AACAB306</string>
-				<string>24A4B4617E61A71C15E2CC09</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>iOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>08A519CBE92BE62AD21FACAA</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>09C465CADCDEBF1CF3977BA3</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>92447C53D3D6A7191EF39393</string>
-			<key>buildPhases</key>
-			<array>
-				<string>8183EA0070D45C4197210EBF</string>
-				<string>50225F21CFA0BBC285F28CD7</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>639971B485A1F78DD9FF2910</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-BAFluidView</string>
-			<key>productName</key>
-			<string>Pods-BAFluidView</string>
-			<key>productReference</key>
-			<string>93020F5A7EBD0B7173206F20</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>166086873129B4A8FCB0952F</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-BAFluidView-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>16F4CE6BE74C83369354861A</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>CDC467D14256656EB78759BA</string>
-				<string>5826A705CCF15689AD7E2C3D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>18DE1D5BD591DC5FAE956566</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>Pods-Tests-BAFluidView-prefix.pch</string>
-			<key>path</key>
-			<string>../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1D5010100358925CA2E819AC</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-Tests.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>219A8075C9BE64C4DE098A8B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>24A4B4617E61A71C15E2CC09</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>22029149A81D15EE84387F23</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>AC796F5EF03A555F3E9115A0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-BAFluidView-BAFluidView/Pods-BAFluidView-BAFluidView-prefix.pch</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>234920B533770B45AACAB306</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>23ED7C82675E0A08069E13B6</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>B8334FACDF1721ACF4E62062</string>
-				<string>22029149A81D15EE84387F23</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>240B47C6BD38ADA096347D71</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>48CE583BA45D15164890854C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>24A4B4617E61A71C15E2CC09</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>2515A2071F3C4D3AC993FDAB</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>5EC593535AF885F78A95A11A</string>
-				<string>EE95F4CBC20205E155504CF6</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>2545CCFFB175F1FCCB45A437</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2634F27C3C95C8B428FA4FAF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.script.sh</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-resources.sh</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>26B6084F6578DB819DCB2B9E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>571A159735CCE8CFCB6CE27D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-DOS_OBJECT_USE_OBJC=0</string>
-			</dict>
-		</dict>
-		<key>275AC94588689B6FD5B616EB</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-Tests-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2E62769E0289D96A82C43CD7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>234920B533770B45AACAB306</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3090FC61F05E227326ABDD70</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D2E036D8AF6B88DD3272F409</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-DOS_OBJECT_USE_OBJC=0</string>
-			</dict>
-		</dict>
-		<key>3692AD5806DB929799132A0D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Tests-BAFluidView-Private.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>36B79B56BEEA089A11B8AD90</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3090FC61F05E227326ABDD70</string>
-				<string>26B6084F6578DB819DCB2B9E</string>
-				<string>4C1562394633D8674BBB43A7</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>3BD63826ADA742AF8A1B8864</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BD4509C698E15858C4FFD8D9</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3CC3FDDAEA3E8F1E619C0946</key>
-		<dict>
-			<key>fileRef</key>
-			<string>234920B533770B45AACAB306</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>3D73CD52F90140192E7F7849</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0510</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>72ECED8055F46D52AED94BC8</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>C7ACC8F69CE35FAA3A304745</string>
-			<key>productRefGroup</key>
-			<string>A5B2DD60A6A2B2ED1B80FC0E</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>04CF807E1DAA4B60B1116A01</string>
-				<string>09C465CADCDEBF1CF3977BA3</string>
-				<string>4C2474190D065646B0066627</string>
-				<string>52D2D4AB259D37930420DF60</string>
-				<string>AF7E524226AEBB578268D442</string>
-			</array>
-		</dict>
-		<key>3FF5EC1ED85DC36124C717E0</key>
-		<dict>
-			<key>fileRef</key>
-			<string>963D6C817874F24B44D442B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>41346E5BFB11B6F0D35357BF</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-BAFluidView.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>41E89AD88F2B4F4CEF802688</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>3692AD5806DB929799132A0D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>48CE583BA45D15164890854C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>FCAB92F8A4DE54F8A1CF01B8</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4AD9D84B77FD03FCB8975DF4</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>275AC94588689B6FD5B616EB</string>
-				<string>8D3BDFA03A0D9D7C6F8BEF93</string>
-				<string>FCAB92F8A4DE54F8A1CF01B8</string>
-				<string>BC633AF22217D27B907D054A</string>
-				<string>00C3CA131475187322B83C7A</string>
-				<string>1D5010100358925CA2E819AC</string>
-				<string>F61BF5F0E49CA5BAE52EE449</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-Tests</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-Tests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C1562394633D8674BBB43A7</key>
-		<dict>
-			<key>fileRef</key>
-			<string>C736DCA3621F8E0A588265B1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C2474190D065646B0066627</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>23ED7C82675E0A08069E13B6</string>
-			<key>buildPhases</key>
-			<array>
-				<string>BA774C95FF8A161E39C9DC07</string>
-				<string>D69BF1418D7FF61838BEB3C2</string>
-				<string>874210B2CFB1E24E1F51CA09</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>5553BC23DE98BCC958041480</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-BAFluidView-BAFluidView</string>
-			<key>productName</key>
-			<string>Pods-BAFluidView-BAFluidView</string>
-			<key>productReference</key>
-			<string>E0EB6231FE4C0DA7A48A2796</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>4F820C5BEAD1DE009AE8EF3C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>57FB19963BD3CB14D004DB33</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4FBCF54A1E8AFBC0A6738512</key>
-		<dict>
-			<key>fileRef</key>
-			<string>2545CCFFB175F1FCCB45A437</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>50225F21CFA0BBC285F28CD7</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>2E62769E0289D96A82C43CD7</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>52D2D4AB259D37930420DF60</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>2515A2071F3C4D3AC993FDAB</string>
-			<key>buildPhases</key>
-			<array>
-				<string>240B47C6BD38ADA096347D71</string>
-				<string>EAAAB19EB5B25C581E5DA86B</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>E47EC62F1397BD5F16262983</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-Tests</string>
-			<key>productName</key>
-			<string>Pods-Tests</string>
-			<key>productReference</key>
-			<string>0345735DA555D09D8A059AB8</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>53B223A6B70D73C165E16B66</key>
-		<dict>
-			<key>fileRef</key>
-			<string>571A159735CCE8CFCB6CE27D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-DOS_OBJECT_USE_OBJC=0</string>
-			</dict>
-		</dict>
-		<key>5553BC23DE98BCC958041480</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>BAFluidView</string>
-			<key>target</key>
-			<string>04CF807E1DAA4B60B1116A01</string>
-			<key>targetProxy</key>
-			<string>AA45ECB5E789143FE87738FB</string>
-		</dict>
-		<key>571A159735CCE8CFCB6CE27D</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>BAUtil.m</string>
-			<key>path</key>
-			<string>Pod/Classes/BAUtil.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>57FB19963BD3CB14D004DB33</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>BAUtil.h</string>
-			<key>path</key>
-			<string>Pod/Classes/BAUtil.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5826A705CCF15689AD7E2C3D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>24A4B4617E61A71C15E2CC09</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5ABF0424E148CB79E75A2360</key>
-		<dict>
-			<key>fileRef</key>
-			<string>234920B533770B45AACAB306</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>5E276F8A7AFADDEFF09C27FF</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>9F363E605871EC9DB1329722</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>5EC593535AF885F78A95A11A</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1D5010100358925CA2E819AC</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>62333B359B9B114A1B158BAA</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>3D73CD52F90140192E7F7849</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>04CF807E1DAA4B60B1116A01</string>
-			<key>remoteInfo</key>
-			<string>BAFluidView</string>
-		</dict>
-		<key>6361439A1325AD2C371C3AF5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-acknowledgements.markdown</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>639971B485A1F78DD9FF2910</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-BAFluidView-BAFluidView</string>
-			<key>target</key>
-			<string>4C2474190D065646B0066627</string>
-			<key>targetProxy</key>
-			<string>652B38E536EEB1E2E3DAF9C0</string>
-		</dict>
-		<key>652B38E536EEB1E2E3DAF9C0</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>3D73CD52F90140192E7F7849</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>4C2474190D065646B0066627</string>
-			<key>remoteInfo</key>
-			<string>Pods-BAFluidView-BAFluidView</string>
-		</dict>
-		<key>6A351570A658BF6A35A22FB6</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>RELEASE=1</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>6A4C173579F179ADE8717BC0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-Tests-BAFluidView.xcconfig</string>
-			<key>path</key>
-			<string>../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>72ECED8055F46D52AED94BC8</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>B49580DBB238A8424E9DCB25</string>
-				<string>6A351570A658BF6A35A22FB6</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>734A053316B8E8463D44C6C0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-BAFluidView.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>73E0CB68324E0DB0FFBC1F68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>D2E036D8AF6B88DD3272F409</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-			<key>settings</key>
-			<dict>
-				<key>COMPILER_FLAGS</key>
-				<string>-DOS_OBJECT_USE_OBJC=0</string>
-			</dict>
-		</dict>
-		<key>7566060A949AD33CD3546FAD</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>3D73CD52F90140192E7F7849</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>AF7E524226AEBB578268D442</string>
-			<key>remoteInfo</key>
-			<string>Pods-Tests-BAFluidView</string>
-		</dict>
-		<key>794E77DAB7124ADC74A0BE01</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>7BA3CB1F321F721A379EB2D1</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E24A3A2FDF4D0739D7B2C4D3</string>
-				<string>4F820C5BEAD1DE009AE8EF3C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>8183EA0070D45C4197210EBF</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4FBCF54A1E8AFBC0A6738512</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>874210B2CFB1E24E1F51CA09</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3FF5EC1ED85DC36124C717E0</string>
-				<string>AB761505616AFE7C17A0A4B3</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>8814553D61712F634AC06351</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>963D6C817874F24B44D442B5</string>
-				<string>D2E036D8AF6B88DD3272F409</string>
-				<string>57FB19963BD3CB14D004DB33</string>
-				<string>571A159735CCE8CFCB6CE27D</string>
-				<string>F51B74D305632D6152FE4860</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>BAFluidView</string>
-			<key>path</key>
-			<string>../..</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8A3C0FD7778BD1C4F65CFBE6</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8D3BDFA03A0D9D7C6F8BEF93</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Pods-Tests-acknowledgements.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>91A2F661FC030D7B59B621FF</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>bundle</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>92447C53D3D6A7191EF39393</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>5E276F8A7AFADDEFF09C27FF</string>
-				<string>B3BAAA7CA97E531424CDC158</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>93020F5A7EBD0B7173206F20</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BAFluidView.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>96010581A69760ED18C74D65</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>963D6C817874F24B44D442B5</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>name</key>
-			<string>BAFluidView.h</string>
-			<key>path</key>
-			<string>Pod/Classes/BAFluidView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9CE2A8D2231D79E6FA27D05C</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>CDA9B7A8791375638D4C7727</string>
-				<string>91A2F661FC030D7B59B621FF</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>9F363E605871EC9DB1329722</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-BAFluidView.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A064861100A9A1EB93ACBE7F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>07116E5EC71F54CAEADBEA16</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A5B2DD60A6A2B2ED1B80FC0E</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F8B60D316F015FA1D9CB98BF</string>
-				<string>93020F5A7EBD0B7173206F20</string>
-				<string>E0EB6231FE4C0DA7A48A2796</string>
-				<string>0345735DA555D09D8A059AB8</string>
-				<string>02A79ABE3AEC3030271BEAA7</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>A89BFE013002DB90508926EC</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>C5ACE85058B11E6269663BC6</string>
-				<string>4AD9D84B77FD03FCB8975DF4</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Targets Support Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AA45ECB5E789143FE87738FB</key>
-		<dict>
-			<key>containerPortal</key>
-			<string>3D73CD52F90140192E7F7849</string>
-			<key>isa</key>
-			<string>PBXContainerItemProxy</string>
-			<key>proxyType</key>
-			<string>1</string>
-			<key>remoteGlobalIDString</key>
-			<string>04CF807E1DAA4B60B1116A01</string>
-			<key>remoteInfo</key>
-			<string>BAFluidView</string>
-		</dict>
-		<key>AB761505616AFE7C17A0A4B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>57FB19963BD3CB14D004DB33</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>AC796F5EF03A555F3E9115A0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-BAFluidView-Private.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>AF7E524226AEBB578268D442</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>D072B5333407760F00C6AED5</string>
-			<key>buildPhases</key>
-			<array>
-				<string>36B79B56BEEA089A11B8AD90</string>
-				<string>16F4CE6BE74C83369354861A</string>
-				<string>7BA3CB1F321F721A379EB2D1</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array>
-				<string>CFD3232EF863981E31BF7203</string>
-			</array>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Pods-Tests-BAFluidView</string>
-			<key>productName</key>
-			<string>Pods-Tests-BAFluidView</string>
-			<key>productReference</key>
-			<string>02A79ABE3AEC3030271BEAA7</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>B3BAAA7CA97E531424CDC158</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>734A053316B8E8463D44C6C0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>B49580DBB238A8424E9DCB25</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>B8334FACDF1721ACF4E62062</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>AC796F5EF03A555F3E9115A0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Target Support Files/Pods-BAFluidView-BAFluidView/Pods-BAFluidView-BAFluidView-prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>BA774C95FF8A161E39C9DC07</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>73E0CB68324E0DB0FFBC1F68</string>
-				<string>53B223A6B70D73C165E16B66</string>
-				<string>3BD63826ADA742AF8A1B8864</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BC633AF22217D27B907D054A</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Pods-Tests-environment.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BD4509C698E15858C4FFD8D9</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-BAFluidView-BAFluidView-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C5ACE85058B11E6269663BC6</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>6361439A1325AD2C371C3AF5</string>
-				<string>08A519CBE92BE62AD21FACAA</string>
-				<string>2545CCFFB175F1FCCB45A437</string>
-				<string>8A3C0FD7778BD1C4F65CFBE6</string>
-				<string>2634F27C3C95C8B428FA4FAF</string>
-				<string>9F363E605871EC9DB1329722</string>
-				<string>734A053316B8E8463D44C6C0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods-BAFluidView</string>
-			<key>path</key>
-			<string>Target Support Files/Pods-BAFluidView</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C736DCA3621F8E0A588265B1</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>Pods-Tests-BAFluidView-dummy.m</string>
-			<key>path</key>
-			<string>../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>C7ACC8F69CE35FAA3A304745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E6F9B063607C7050AC6B5499</string>
-				<string>CE426E7BC983D9F62487F1F0</string>
-				<string>A064861100A9A1EB93ACBE7F</string>
-				<string>A5B2DD60A6A2B2ED1B80FC0E</string>
-				<string>A89BFE013002DB90508926EC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CDA9B7A8791375638D4C7727</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>bundle</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>CDC467D14256656EB78759BA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>234920B533770B45AACAB306</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>CE426E7BC983D9F62487F1F0</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8814553D61712F634AC06351</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Development Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>CFD3232EF863981E31BF7203</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>BAFluidView</string>
-			<key>target</key>
-			<string>04CF807E1DAA4B60B1116A01</string>
-			<key>targetProxy</key>
-			<string>62333B359B9B114A1B158BAA</string>
-		</dict>
-		<key>D072B5333407760F00C6AED5</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>41E89AD88F2B4F4CEF802688</string>
-				<string>00CC2A2D7A67ACD10BDDBB81</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>D2E036D8AF6B88DD3272F409</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>name</key>
-			<string>BAFluidView.m</string>
-			<key>path</key>
-			<string>Pod/Classes/BAFluidView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>D69BF1418D7FF61838BEB3C2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>5ABF0424E148CB79E75A2360</string>
-				<string>219A8075C9BE64C4DE098A8B</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>E0EB6231FE4C0DA7A48A2796</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BAFluidView-BAFluidView.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>E24A3A2FDF4D0739D7B2C4D3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>963D6C817874F24B44D442B5</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E47EC62F1397BD5F16262983</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXTargetDependency</string>
-			<key>name</key>
-			<string>Pods-Tests-BAFluidView</string>
-			<key>target</key>
-			<string>AF7E524226AEBB578268D442</string>
-			<key>targetProxy</key>
-			<string>7566060A949AD33CD3546FAD</string>
-		</dict>
-		<key>E6F9B063607C7050AC6B5499</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>name</key>
-			<string>Podfile</string>
-			<key>path</key>
-			<string>../Podfile</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-			<key>xcLanguageSpecificationIdentifier</key>
-			<string>xcode.lang.ruby</string>
-		</dict>
-		<key>EAAAB19EB5B25C581E5DA86B</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>3CC3FDDAEA3E8F1E619C0946</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>EE95F4CBC20205E155504CF6</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>F61BF5F0E49CA5BAE52EE449</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DSTROOT</key>
-				<string>/tmp/xcodeproj.dst</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>INSTALL_PATH</key>
-				<string>$(BUILT_PRODUCTS_DIR)</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>8.0</string>
-				<key>OTHER_CFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_CPLUSPLUSFLAGS</key>
-				<array>
-					<string>-DNS_BLOCK_ASSERTIONS=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string></string>
-				<key>OTHER_LIBTOOLFLAGS</key>
-				<string></string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
-				<string>$(TARGET_NAME)</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>F51B74D305632D6152FE4860</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>41346E5BFB11B6F0D35357BF</string>
-				<string>AC796F5EF03A555F3E9115A0</string>
-				<string>BD4509C698E15858C4FFD8D9</string>
-				<string>166086873129B4A8FCB0952F</string>
-				<string>6A4C173579F179ADE8717BC0</string>
-				<string>3692AD5806DB929799132A0D</string>
-				<string>C736DCA3621F8E0A588265B1</string>
-				<string>18DE1D5BD591DC5FAE956566</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Support Files</string>
-			<key>path</key>
-			<string>Example/Pods/Target Support Files/Pods-BAFluidView-BAFluidView</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F53AB24F68EF8C8E93664481</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F61BF5F0E49CA5BAE52EE449</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Pods-Tests.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F8B60D316F015FA1D9CB98BF</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BAFluidView.bundle</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>FCAB92F8A4DE54F8A1CF01B8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>Pods-Tests-dummy.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>3D73CD52F90140192E7F7849</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0B71CA405C93DAADE0975FD7 /* BAFluidView.h in Headers */ = {isa = PBXBuildFile; fileRef = 87071D348AEAB3EE27E0F883 /* BAFluidView.h */; };
+		3A2A4BB79C55BEE23F7B7FCC /* Pods-Tests-BAFluidView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 64B6270E82CC14A516825A66 /* Pods-Tests-BAFluidView-dummy.m */; };
+		581F6D85F272E0BFC9591EFB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 520AC95E38C6985AE4F6F648 /* Foundation.framework */; };
+		7A09A0C241BB8FFF6AB66DEC /* UIColor+ColorWithHex.h in Headers */ = {isa = PBXBuildFile; fileRef = 73AFDD0E6E5C9790DB089113 /* UIColor+ColorWithHex.h */; };
+		7A0CE4F61CD9ED18DA024A09 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 707CF1A7732DC4A3D611CC95 /* UIKit.framework */; };
+		8343F60D8DFFDF88913BF7A1 /* UIColor+ColorWithHex.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB47FB160259992934FFA2F /* UIColor+ColorWithHex.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		9F25A5FFC132ECFA3B96D51C /* BAFluidView.m in Sources */ = {isa = PBXBuildFile; fileRef = 907961A8B4E80A67030C73A9 /* BAFluidView.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		A238B50E69A17B24992E8696 /* BAFluidView.h in Headers */ = {isa = PBXBuildFile; fileRef = 87071D348AEAB3EE27E0F883 /* BAFluidView.h */; };
+		A9B6240FAE8999D097B94B8A /* Pods-BAFluidView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F4BF8C00161B1DAAD9F51CA6 /* Pods-BAFluidView-dummy.m */; };
+		AEF3B26A02CF70195BA3CCE3 /* UIColor+ColorWithHex.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB47FB160259992934FFA2F /* UIColor+ColorWithHex.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		B75E015DF63C9A73C8551876 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 520AC95E38C6985AE4F6F648 /* Foundation.framework */; };
+		B774113DA30B1403EFBB3C57 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 520AC95E38C6985AE4F6F648 /* Foundation.framework */; };
+		BF121533ADBEABBB5A338212 /* BAFluidView.m in Sources */ = {isa = PBXBuildFile; fileRef = 907961A8B4E80A67030C73A9 /* BAFluidView.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		C31686CBB6A0E19E400CB769 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 707CF1A7732DC4A3D611CC95 /* UIKit.framework */; };
+		CB5862379897BB0318EE27B4 /* Pods-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E402BCB4E2157A3CC0C9966C /* Pods-Tests-dummy.m */; };
+		D30283D4612A00CCB858326B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 520AC95E38C6985AE4F6F648 /* Foundation.framework */; };
+		EF5166FFB4504B11BE4F25C1 /* UIColor+ColorWithHex.h in Headers */ = {isa = PBXBuildFile; fileRef = 73AFDD0E6E5C9790DB089113 /* UIColor+ColorWithHex.h */; };
+		F2EDEC4DDCB1D76FDD9EE412 /* Pods-BAFluidView-BAFluidView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 01D3CC91F51530E3611564D1 /* Pods-BAFluidView-BAFluidView-dummy.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		170793987BBDE8CE5AAA4C0A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 56677A7068B081EA68DFC1A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B3358B368197EA1CA4323B39;
+			remoteInfo = "Pods-BAFluidView-BAFluidView-BAFluidView";
+		};
+		3E4C5D382E233A8726AED500 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 56677A7068B081EA68DFC1A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F641BBC5E1A4480DA4986841;
+			remoteInfo = "Pods-BAFluidView-BAFluidView";
+		};
+		43C67D1B31A42CCDC2703A98 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 56677A7068B081EA68DFC1A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4D2460A226F860D851070B63;
+			remoteInfo = "Pods-Tests-BAFluidView";
+		};
+		59719DA31883649EF3960BD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 56677A7068B081EA68DFC1A2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CBAED69EE9B0B153104A0C30;
+			remoteInfo = "Pods-Tests-BAFluidView-BAFluidView";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		00928D175F3E6A1AE6E98621 /* Pods-BAFluidView-BAFluidView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-BAFluidView-BAFluidView-prefix.pch"; sourceTree = "<group>"; };
+		01D3CC91F51530E3611564D1 /* Pods-BAFluidView-BAFluidView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-BAFluidView-BAFluidView-dummy.m"; sourceTree = "<group>"; };
+		145551AFC5895677477CA4BF /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		1EB47FB160259992934FFA2F /* UIColor+ColorWithHex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIColor+ColorWithHex.m"; sourceTree = "<group>"; };
+		20B415681F8BA745AD08782D /* libPods-Tests-BAFluidView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests-BAFluidView.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		220C5AE68AFA462C0DF4002C /* Pods-BAFluidView-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-BAFluidView-acknowledgements.plist"; sourceTree = "<group>"; };
+		235B9F9B66F51A3B53BB17EC /* Pods-Tests-BAFluidView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-Tests-BAFluidView-prefix.pch"; path = "../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-prefix.pch"; sourceTree = "<group>"; };
+		45FB370E736210A9D699C3E5 /* Pods-BAFluidView-BAFluidView-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BAFluidView-BAFluidView-Private.xcconfig"; sourceTree = "<group>"; };
+		520AC95E38C6985AE4F6F648 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		59BD57A25AC77CECBF5078E4 /* Pods-BAFluidView.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BAFluidView.debug.xcconfig"; sourceTree = "<group>"; };
+		64B6270E82CC14A516825A66 /* Pods-Tests-BAFluidView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-Tests-BAFluidView-dummy.m"; path = "../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-dummy.m"; sourceTree = "<group>"; };
+		69D336A762D6B59DA1A00330 /* Pods-BAFluidView.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BAFluidView.release.xcconfig"; sourceTree = "<group>"; };
+		707CF1A7732DC4A3D611CC95 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		73AFDD0E6E5C9790DB089113 /* UIColor+ColorWithHex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIColor+ColorWithHex.h"; sourceTree = "<group>"; };
+		74992F9DAF6ADA69CFA21B4F /* Pods-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Tests-resources.sh"; sourceTree = "<group>"; };
+		74D608FB01C59D8A3BF47760 /* Pods-Tests-BAFluidView-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BAFluidView-Private.xcconfig"; path = "../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-Private.xcconfig"; sourceTree = "<group>"; };
+		7C5B9C33ABB772FBB76C1F3C /* Pods-BAFluidView-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-BAFluidView-acknowledgements.markdown"; sourceTree = "<group>"; };
+		7DE5A15092D8EF2997E312E1 /* Pods-BAFluidView-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-BAFluidView-resources.sh"; sourceTree = "<group>"; };
+		7E4ED65AE896B67D57361860 /* Pods-Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Tests-environment.h"; sourceTree = "<group>"; };
+		87071D348AEAB3EE27E0F883 /* BAFluidView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = BAFluidView.h; sourceTree = "<group>"; };
+		8BBAF5F338FF72CC854E4D17 /* Pods-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		907961A8B4E80A67030C73A9 /* BAFluidView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = BAFluidView.m; sourceTree = "<group>"; };
+		914FE2FEA96035B6B389FA5D /* libPods-BAFluidView-BAFluidView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BAFluidView-BAFluidView.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B794363CDF64A8785D96665 /* libPods-BAFluidView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BAFluidView.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B0F9ADA2B71BBBFECBA636B8 /* Pods-BAFluidView-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-BAFluidView-environment.h"; sourceTree = "<group>"; };
+		B650705213A7DB451D1B655D /* Pods-BAFluidView-BAFluidView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-BAFluidView-BAFluidView.xcconfig"; sourceTree = "<group>"; };
+		CCC23A60475F9529DFC5BBA2 /* Pods-Tests-BAFluidView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-BAFluidView.xcconfig"; path = "../Pods-Tests-BAFluidView/Pods-Tests-BAFluidView.xcconfig"; sourceTree = "<group>"; };
+		CDEBA2013615CCC586494A55 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		D57529D7300528F60A201534 /* BAFluidView.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BAFluidView.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF19341406D133F7DD52EBFF /* Pods-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		DF44F08B120453ED16852715 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		E402BCB4E2157A3CC0C9966C /* Pods-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Tests-dummy.m"; sourceTree = "<group>"; };
+		E682339B20D2D66C36A4E299 /* BAFluidView.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BAFluidView.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		EDE6C8CF789B97E84BC1E946 /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4BF8C00161B1DAAD9F51CA6 /* Pods-BAFluidView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-BAFluidView-dummy.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0A3C4386A6E16DD91A85EAF6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D30283D4612A00CCB858326B /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4490CDC701DB8083EC396434 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				581F6D85F272E0BFC9591EFB /* Foundation.framework in Frameworks */,
+				7A0CE4F61CD9ED18DA024A09 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		58CB872833E8A33B60285732 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CAD256D090D42FA0BCF07578 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B75E015DF63C9A73C8551876 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD11AEC6FE2A1C942FC3D187 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B774113DA30B1403EFBB3C57 /* Foundation.framework in Frameworks */,
+				C31686CBB6A0E19E400CB769 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FEB935F714F11EEDA7DB966F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		31D0E0AE5EA792428078CA63 /* Pods-BAFluidView */ = {
+			isa = PBXGroup;
+			children = (
+				7C5B9C33ABB772FBB76C1F3C /* Pods-BAFluidView-acknowledgements.markdown */,
+				220C5AE68AFA462C0DF4002C /* Pods-BAFluidView-acknowledgements.plist */,
+				F4BF8C00161B1DAAD9F51CA6 /* Pods-BAFluidView-dummy.m */,
+				B0F9ADA2B71BBBFECBA636B8 /* Pods-BAFluidView-environment.h */,
+				7DE5A15092D8EF2997E312E1 /* Pods-BAFluidView-resources.sh */,
+				59BD57A25AC77CECBF5078E4 /* Pods-BAFluidView.debug.xcconfig */,
+				69D336A762D6B59DA1A00330 /* Pods-BAFluidView.release.xcconfig */,
+			);
+			name = "Pods-BAFluidView";
+			path = "Target Support Files/Pods-BAFluidView";
+			sourceTree = "<group>";
+		};
+		45FC2C2C277D4B89DEFA2C42 /* Pods-Tests */ = {
+			isa = PBXGroup;
+			children = (
+				8BBAF5F338FF72CC854E4D17 /* Pods-Tests-acknowledgements.markdown */,
+				DF19341406D133F7DD52EBFF /* Pods-Tests-acknowledgements.plist */,
+				E402BCB4E2157A3CC0C9966C /* Pods-Tests-dummy.m */,
+				7E4ED65AE896B67D57361860 /* Pods-Tests-environment.h */,
+				74992F9DAF6ADA69CFA21B4F /* Pods-Tests-resources.sh */,
+				145551AFC5895677477CA4BF /* Pods-Tests.debug.xcconfig */,
+				DF44F08B120453ED16852715 /* Pods-Tests.release.xcconfig */,
+			);
+			name = "Pods-Tests";
+			path = "Target Support Files/Pods-Tests";
+			sourceTree = "<group>";
+		};
+		6A1B88BE2BC1D633BECDA37D /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				946D39339025DC7F80E166ED /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		6B37C34C6E12733C0A29AB7B /* BAFluidView */ = {
+			isa = PBXGroup;
+			children = (
+				6A1B88BE2BC1D633BECDA37D /* Pod */,
+				7600917586A91B542AA4A3CC /* Support Files */,
+			);
+			name = BAFluidView;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		7600917586A91B542AA4A3CC /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				B650705213A7DB451D1B655D /* Pods-BAFluidView-BAFluidView.xcconfig */,
+				45FB370E736210A9D699C3E5 /* Pods-BAFluidView-BAFluidView-Private.xcconfig */,
+				01D3CC91F51530E3611564D1 /* Pods-BAFluidView-BAFluidView-dummy.m */,
+				00928D175F3E6A1AE6E98621 /* Pods-BAFluidView-BAFluidView-prefix.pch */,
+				CCC23A60475F9529DFC5BBA2 /* Pods-Tests-BAFluidView.xcconfig */,
+				74D608FB01C59D8A3BF47760 /* Pods-Tests-BAFluidView-Private.xcconfig */,
+				64B6270E82CC14A516825A66 /* Pods-Tests-BAFluidView-dummy.m */,
+				235B9F9B66F51A3B53BB17EC /* Pods-Tests-BAFluidView-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Pods-BAFluidView-BAFluidView";
+			sourceTree = "<group>";
+		};
+		88BE33FB04D85167E33A32F4 = {
+			isa = PBXGroup;
+			children = (
+				CDEBA2013615CCC586494A55 /* Podfile */,
+				EC5706558F9E35185822CB3F /* Development Pods */,
+				FC08082AE2139FD319C6960C /* Frameworks */,
+				DC934F09AAE1AF4E95DCA1CF /* Products */,
+				DBC78647FC385C21395E7215 /* Targets Support Files */,
+			);
+			sourceTree = "<group>";
+		};
+		946D39339025DC7F80E166ED /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				87071D348AEAB3EE27E0F883 /* BAFluidView.h */,
+				907961A8B4E80A67030C73A9 /* BAFluidView.m */,
+				73AFDD0E6E5C9790DB089113 /* UIColor+ColorWithHex.h */,
+				1EB47FB160259992934FFA2F /* UIColor+ColorWithHex.m */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		A48E7E1CB3DD239253DCB9C3 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				520AC95E38C6985AE4F6F648 /* Foundation.framework */,
+				707CF1A7732DC4A3D611CC95 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		DBC78647FC385C21395E7215 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				31D0E0AE5EA792428078CA63 /* Pods-BAFluidView */,
+				45FC2C2C277D4B89DEFA2C42 /* Pods-Tests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		DC934F09AAE1AF4E95DCA1CF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E682339B20D2D66C36A4E299 /* BAFluidView.bundle */,
+				D57529D7300528F60A201534 /* BAFluidView.bundle */,
+				9B794363CDF64A8785D96665 /* libPods-BAFluidView.a */,
+				914FE2FEA96035B6B389FA5D /* libPods-BAFluidView-BAFluidView.a */,
+				EDE6C8CF789B97E84BC1E946 /* libPods-Tests.a */,
+				20B415681F8BA745AD08782D /* libPods-Tests-BAFluidView.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EC5706558F9E35185822CB3F /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6B37C34C6E12733C0A29AB7B /* BAFluidView */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		FC08082AE2139FD319C6960C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A48E7E1CB3DD239253DCB9C3 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		146F6FFC5C02AFBF72D3B359 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A238B50E69A17B24992E8696 /* BAFluidView.h in Headers */,
+				7A09A0C241BB8FFF6AB66DEC /* UIColor+ColorWithHex.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DD6B3AB30B99BCE67DDCEBEC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B71CA405C93DAADE0975FD7 /* BAFluidView.h in Headers */,
+				EF5166FFB4504B11BE4F25C1 /* UIColor+ColorWithHex.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		276A43BDD498955494C9886D /* Pods-BAFluidView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D79EABBA4A6CAD8B90017F6B /* Build configuration list for PBXNativeTarget "Pods-BAFluidView" */;
+			buildPhases = (
+				E3810E49CDD5D639BC18ABCC /* Sources */,
+				0A3C4386A6E16DD91A85EAF6 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				41EC7CA2BAD0CC9B2EFFF9D6 /* PBXTargetDependency */,
+			);
+			name = "Pods-BAFluidView";
+			productName = "Pods-BAFluidView";
+			productReference = 9B794363CDF64A8785D96665 /* libPods-BAFluidView.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		4D2460A226F860D851070B63 /* Pods-Tests-BAFluidView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 01395472EF06551C89AAE069 /* Build configuration list for PBXNativeTarget "Pods-Tests-BAFluidView" */;
+			buildPhases = (
+				4C5B183DAC83A2C3B7833262 /* Sources */,
+				4490CDC701DB8083EC396434 /* Frameworks */,
+				146F6FFC5C02AFBF72D3B359 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				296B3762BB8FE4FB321DBAF3 /* PBXTargetDependency */,
+			);
+			name = "Pods-Tests-BAFluidView";
+			productName = "Pods-Tests-BAFluidView";
+			productReference = 20B415681F8BA745AD08782D /* libPods-Tests-BAFluidView.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		6DACDB1E6DE107834A8F24AF /* Pods-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 86FA07291B092401EBC86948 /* Build configuration list for PBXNativeTarget "Pods-Tests" */;
+			buildPhases = (
+				2A1E8ABED5D2B258A305B403 /* Sources */,
+				CAD256D090D42FA0BCF07578 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				57BC5477E25EEC99318AE83E /* PBXTargetDependency */,
+			);
+			name = "Pods-Tests";
+			productName = "Pods-Tests";
+			productReference = EDE6C8CF789B97E84BC1E946 /* libPods-Tests.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		B3358B368197EA1CA4323B39 /* Pods-BAFluidView-BAFluidView-BAFluidView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 26FFD7A7DBFDAB531BAC86E7 /* Build configuration list for PBXNativeTarget "Pods-BAFluidView-BAFluidView-BAFluidView" */;
+			buildPhases = (
+				CCC4CD3AEE85437450A81537 /* Sources */,
+				58CB872833E8A33B60285732 /* Frameworks */,
+				71ED89E4882EB389255B35DA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-BAFluidView-BAFluidView-BAFluidView";
+			productName = "Pods-BAFluidView-BAFluidView-BAFluidView";
+			productReference = D57529D7300528F60A201534 /* BAFluidView.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		CBAED69EE9B0B153104A0C30 /* Pods-Tests-BAFluidView-BAFluidView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7BADF1A21B1985053F17C7F0 /* Build configuration list for PBXNativeTarget "Pods-Tests-BAFluidView-BAFluidView" */;
+			buildPhases = (
+				2C88B3068ED3AFF4A1AFAF57 /* Sources */,
+				FEB935F714F11EEDA7DB966F /* Frameworks */,
+				366A31EC60B3B956D6FEE189 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-Tests-BAFluidView-BAFluidView";
+			productName = "Pods-Tests-BAFluidView-BAFluidView";
+			productReference = E682339B20D2D66C36A4E299 /* BAFluidView.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		F641BBC5E1A4480DA4986841 /* Pods-BAFluidView-BAFluidView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BC3D81C0EF7F16822364DF08 /* Build configuration list for PBXNativeTarget "Pods-BAFluidView-BAFluidView" */;
+			buildPhases = (
+				8903B82E2FB6F9AFD1ABB29F /* Sources */,
+				CD11AEC6FE2A1C942FC3D187 /* Frameworks */,
+				DD6B3AB30B99BCE67DDCEBEC /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				03D9148DA5C083D37EFFA8F2 /* PBXTargetDependency */,
+			);
+			name = "Pods-BAFluidView-BAFluidView";
+			productName = "Pods-BAFluidView-BAFluidView";
+			productReference = 914FE2FEA96035B6B389FA5D /* libPods-BAFluidView-BAFluidView.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		56677A7068B081EA68DFC1A2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0640;
+			};
+			buildConfigurationList = DE9562D622A36C9BF5A7754F /* Build configuration list for PBXProject "Pods" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 88BE33FB04D85167E33A32F4;
+			productRefGroup = DC934F09AAE1AF4E95DCA1CF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				276A43BDD498955494C9886D /* Pods-BAFluidView */,
+				F641BBC5E1A4480DA4986841 /* Pods-BAFluidView-BAFluidView */,
+				B3358B368197EA1CA4323B39 /* Pods-BAFluidView-BAFluidView-BAFluidView */,
+				6DACDB1E6DE107834A8F24AF /* Pods-Tests */,
+				4D2460A226F860D851070B63 /* Pods-Tests-BAFluidView */,
+				CBAED69EE9B0B153104A0C30 /* Pods-Tests-BAFluidView-BAFluidView */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		366A31EC60B3B956D6FEE189 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		71ED89E4882EB389255B35DA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2A1E8ABED5D2B258A305B403 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB5862379897BB0318EE27B4 /* Pods-Tests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2C88B3068ED3AFF4A1AFAF57 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C5B183DAC83A2C3B7833262 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F25A5FFC132ECFA3B96D51C /* BAFluidView.m in Sources */,
+				3A2A4BB79C55BEE23F7B7FCC /* Pods-Tests-BAFluidView-dummy.m in Sources */,
+				8343F60D8DFFDF88913BF7A1 /* UIColor+ColorWithHex.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8903B82E2FB6F9AFD1ABB29F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF121533ADBEABBB5A338212 /* BAFluidView.m in Sources */,
+				F2EDEC4DDCB1D76FDD9EE412 /* Pods-BAFluidView-BAFluidView-dummy.m in Sources */,
+				AEF3B26A02CF70195BA3CCE3 /* UIColor+ColorWithHex.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC4CD3AEE85437450A81537 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E3810E49CDD5D639BC18ABCC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A9B6240FAE8999D097B94B8A /* Pods-BAFluidView-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		03D9148DA5C083D37EFFA8F2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-BAFluidView-BAFluidView-BAFluidView";
+			target = B3358B368197EA1CA4323B39 /* Pods-BAFluidView-BAFluidView-BAFluidView */;
+			targetProxy = 170793987BBDE8CE5AAA4C0A /* PBXContainerItemProxy */;
+		};
+		296B3762BB8FE4FB321DBAF3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Tests-BAFluidView-BAFluidView";
+			target = CBAED69EE9B0B153104A0C30 /* Pods-Tests-BAFluidView-BAFluidView */;
+			targetProxy = 59719DA31883649EF3960BD4 /* PBXContainerItemProxy */;
+		};
+		41EC7CA2BAD0CC9B2EFFF9D6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-BAFluidView-BAFluidView";
+			target = F641BBC5E1A4480DA4986841 /* Pods-BAFluidView-BAFluidView */;
+			targetProxy = 3E4C5D382E233A8726AED500 /* PBXContainerItemProxy */;
+		};
+		57BC5477E25EEC99318AE83E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-Tests-BAFluidView";
+			target = 4D2460A226F860D851070B63 /* Pods-Tests-BAFluidView */;
+			targetProxy = 43C67D1B31A42CCDC2703A98 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		04B53B3D61D023A40261E05C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74D608FB01C59D8A3BF47760 /* Pods-Tests-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = BAFluidView;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		0D47C7ED93C1A6CEA6335B1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45FB370E736210A9D699C3E5 /* Pods-BAFluidView-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = BAFluidView;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		1DCC0D5059305EB7970755BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DF44F08B120453ED16852715 /* Pods-Tests.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		25BCE46B539B9F888BA45919 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45FB370E736210A9D699C3E5 /* Pods-BAFluidView-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-BAFluidView-BAFluidView/Pods-BAFluidView-BAFluidView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		36B4AC7532FB9C68E01E54C3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74D608FB01C59D8A3BF47760 /* Pods-Tests-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		5084EEEFB7ED16B71281AAB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		59EF6AA2EF580896DC9A29F9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 59BD57A25AC77CECBF5078E4 /* Pods-BAFluidView.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		622B1965DE60022F5FF16DD8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 69D336A762D6B59DA1A00330 /* Pods-BAFluidView.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		782711C18D627DF1A9BBE1E3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74D608FB01C59D8A3BF47760 /* Pods-Tests-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = BAFluidView;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		7E720FF849FE23890B26FD63 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45FB370E736210A9D699C3E5 /* Pods-BAFluidView-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-BAFluidView-BAFluidView/Pods-BAFluidView-BAFluidView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		9A75D3A406C50785A21BA77C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				ONLY_ACTIVE_ARCH = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+			};
+			name = Debug;
+		};
+		A537E24163243112E0EA1F55 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 145551AFC5895677477CA4BF /* Pods-Tests.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		E6B264918FEF0A85DCB3C438 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74D608FB01C59D8A3BF47760 /* Pods-Tests-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-Tests-BAFluidView/Pods-Tests-BAFluidView-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FA8596EAEE291DC842593DC7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 45FB370E736210A9D699C3E5 /* Pods-BAFluidView-BAFluidView-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = BAFluidView;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		01395472EF06551C89AAE069 /* Build configuration list for PBXNativeTarget "Pods-Tests-BAFluidView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E6B264918FEF0A85DCB3C438 /* Debug */,
+				36B4AC7532FB9C68E01E54C3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		26FFD7A7DBFDAB531BAC86E7 /* Build configuration list for PBXNativeTarget "Pods-BAFluidView-BAFluidView-BAFluidView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0D47C7ED93C1A6CEA6335B1A /* Debug */,
+				FA8596EAEE291DC842593DC7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7BADF1A21B1985053F17C7F0 /* Build configuration list for PBXNativeTarget "Pods-Tests-BAFluidView-BAFluidView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				782711C18D627DF1A9BBE1E3 /* Debug */,
+				04B53B3D61D023A40261E05C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		86FA07291B092401EBC86948 /* Build configuration list for PBXNativeTarget "Pods-Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A537E24163243112E0EA1F55 /* Debug */,
+				1DCC0D5059305EB7970755BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BC3D81C0EF7F16822364DF08 /* Build configuration list for PBXNativeTarget "Pods-BAFluidView-BAFluidView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25BCE46B539B9F888BA45919 /* Debug */,
+				7E720FF849FE23890B26FD63 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D79EABBA4A6CAD8B90017F6B /* Build configuration list for PBXNativeTarget "Pods-BAFluidView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				59EF6AA2EF580896DC9A29F9 /* Debug */,
+				622B1965DE60022F5FF16DD8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DE9562D622A36C9BF5A7754F /* Build configuration list for PBXProject "Pods" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A75D3A406C50785A21BA77C /* Debug */,
+				5084EEEFB7ED16B71281AAB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 56677A7068B081EA68DFC1A2 /* Project object */;
+}

--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -21,7 +21,7 @@
 //SOFTWARE.
 
 #import "BAFluidView.h"
-#import "BAUtil.h"
+#import "UIColor+ColorWithHex.h"
 
 @interface BAFluidView()
 
@@ -173,8 +173,8 @@
     // create the wave layer and make it blue
     self.clipsToBounds = YES;
     self.lineLayer = [CAShapeLayer layer];
-    self.lineLayer.fillColor = [BAUtil UIColorFromHex:0x6BB9F0].CGColor;
-    self.lineLayer.strokeColor = [BAUtil UIColorFromHex:0x6BB9F0].CGColor;
+    self.lineLayer.fillColor = [UIColor colorWithHex:0x6BB9F0].CGColor;
+    self.lineLayer.strokeColor = [UIColor colorWithHex:0x6BB9F0].CGColor;
     
     //default wave properties
     self.fillAutoReverse = YES;

--- a/Pod/Classes/UIColor+ColorWithHex.h
+++ b/Pod/Classes/UIColor+ColorWithHex.h
@@ -1,6 +1,6 @@
 //The MIT License (MIT)
 //
-//Copyright (c) 2014 Bryan Antigua <antigua.b@gmail.com>
+//Copyright (c) 2014 Bryan Antigua <antigua.b@gmail.com> Sam Stone <stonesam92@gmail.com>
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +22,8 @@
 
 #import <Foundation/Foundation.h>
 
-@interface BAUtil : NSObject
+@interface UIColor (ColorFromHex)
 
-+(UIColor*)UIColorFromHex:(int)hex;
++(UIColor*)colorWithHex:(int)hex;
 
 @end

--- a/Pod/Classes/UIColor+ColorWithHex.m
+++ b/Pod/Classes/UIColor+ColorWithHex.m
@@ -1,6 +1,6 @@
 //The MIT License (MIT)
 //
-//Copyright (c) 2014 Bryan Antigua <antigua.b@gmail.com>
+//Copyright (c) 2014 Bryan Antigua <antigua.b@gmail.com> Sam Stone <stonesam92@gmail.com>
 //
 //Permission is hereby granted, free of charge, to any person obtaining a copy
 //of this software and associated documentation files (the "Software"), to deal
@@ -20,15 +20,15 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-#import "BAUtil.h"
+#import "UIColor+ColorWithHex.h"
 #define UIColorFromRGB(rgbValue) [UIColor \
 colorWithRed:((float)((rgbValue & 0xFF0000) >> 16))/255.0 \
 green:((float)((rgbValue & 0xFF00) >> 8))/255.0 \
 blue:((float)(rgbValue & 0xFF))/255.0 alpha:1.0]
 
-@implementation BAUtil
+@implementation UIColor (ColorFromHex)
 
-+(UIColor*)UIColorFromHex:(int)hex
++(UIColor*)colorWithHex:(int)hex
 {
     return UIColorFromRGB(hex);
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To add a BAFluidView to your app, add the line:
 ```
 BAFluidView *view = [[BAFluidView alloc] initWithFrame:self.view.frame];
 [view fillTo:@1.0];
-view.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+view.fillColor = [UIColor colorWithHex:0x397ebe];
 [view startAnimation];
 ```
 
@@ -66,7 +66,7 @@ If you only want the effect to fill only once (or any specific amount of times) 
 BAFluidView *view = [[BAFluidView alloc] initWithFrame:self.view.frame maxAmplitude:40 minAmplitude:5 amplitudeIncrement:5];
 view.fillRepeatCount = 1;
 [view fillTo:@1.0];
-view.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+view.fillColor = [UIColor colorWithHex:0x397ebe];
 [view startAnimation];
 ```
 #### Animate Only Once (End in new state)
@@ -74,7 +74,7 @@ You can also create the same effect as above, but stay in the filled state by ed
 
 ```
 BAFluidView *view = [[BAFluidView alloc] initWithFrame:self.view.frame maxAmplitude:40 minAmplitude:5 amplitudeIncrement:5];
-view.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+view.fillColor = [UIColor colorWithHex:0x397ebe];
 view.fillAutoReverse = NO;
 view.fillRepeatCount = 1;
 [view fillTo:@1.0];
@@ -92,7 +92,7 @@ By default, the animation goes to the top of the view. If you don't want it to g
 ```
 BAFluidView *view = [[BAFluidView alloc] initWithFrame:self.view.frame];
 [view fillTo:@0.5];
-view.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+view.fillColor = [UIColor colorWithHex:0x397ebe];
 [view startAnimation];
 ```
 This creates the following view:
@@ -106,7 +106,7 @@ By editing the fillColor property, you can give the fluid any color:
 ```
 BAFluidView *fluidView = [[BAFluidView alloc] initWithFrame:self.view.frame startElevation:@0.5];
 fluidView.strokeColor = [UIColor whiteColor];
-fluidView.fillColor = [BAUtil UIColorFromHex:0x2e353d];
+fluidView.fillColor = [UIColor colorWithHex:0x2e353d];
 [fluidView keepStationary];
 [fluidView startAnimation];
 ```
@@ -137,7 +137,7 @@ If you want to add the effect to another view, use it's layer!
 
 ```
 BAFluidView *fluidView = [[BAFluidView alloc] initWithFrame:self.view.frame startElevation:@0.3];
-fluidView.fillColor = [BAUtil UIColorFromHex:0x397ebe];
+fluidView.fillColor = [UIColor colorWithHex:0x397ebe];
 [fluidView fillTo:@0.9];
 [fluidView startAnimation];
 


### PR DESCRIPTION
Since it is adding functionality to `UIColor`, I thought it would be more sensible to implement `ColorWithHex` as a category on `UIColor` rather than making it a class method in a new class.
