### PR TITLE
Expose max/min and amplitude increment

### DIFF
--- a/Pod/Classes/BAFluidView.h
+++ b/Pod/Classes/BAFluidView.h
@@ -56,6 +56,16 @@ Changes the fill color of the wave animation
 @property(assign,nonatomic) NSNumber *startElavation;
 
 /**
+ Changes the maximum wave crest
+ */
+@property (assign,nonatomic) int maxAmplitude;
+
+/**
+ Changes the minimum wave crest
+ */
+@property (assign,nonatomic) int minAmplitude;
+
+/**
  Returns an object that can create the fluid animation with the given wave properties. This init function lets you adjust the wave crest properties.
  
  @param aRect

--- a/Pod/Classes/BAFluidView.h
+++ b/Pod/Classes/BAFluidView.h
@@ -56,6 +56,11 @@ Changes the fill color of the wave animation
 @property(assign,nonatomic) NSNumber *startElavation;
 
 /**
+ Changes the interval between Max and Min the random function will use
+ */
+@property (assign,nonatomic) int amplitudeIncrement;
+
+/**
  Changes the maximum wave crest
  */
 @property (assign,nonatomic) int maxAmplitude;

--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -32,8 +32,6 @@
 @property (strong,nonatomic) NSArray *amplitudeArray;
 @property (assign,nonatomic) int startingAmplitude;
 @property (assign,nonatomic) int amplitudeIncrement;
-@property (assign,nonatomic) int maxAmplitude;
-@property (assign,nonatomic) int minAmplitude;
 
 @property (strong,nonatomic) NSNumber* startElevation;
 @property (strong,nonatomic) NSNumber* fillLevel;

--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -31,7 +31,6 @@
 
 @property (strong,nonatomic) NSArray *amplitudeArray;
 @property (assign,nonatomic) int startingAmplitude;
-@property (assign,nonatomic) int amplitudeIncrement;
 
 @property (strong,nonatomic) NSNumber* startElevation;
 @property (strong,nonatomic) NSNumber* fillLevel;
@@ -152,7 +151,21 @@
     CGRect frame = self.lineLayer.frame;
     frame.origin.y = CGRectGetHeight(self.rootView.frame)*((1-[_startElavation floatValue]));
     self.lineLayer.frame = frame;
-    
+}
+
+- (void)setMaxAmplitude:(int)maxAmplitude {
+    _maxAmplitude = maxAmplitude;
+    self.amplitudeArray = [self createAmplitudeOptions];
+}
+
+- (void)setMinAmplitude:(int)minAmplitude {
+    _minAmplitude = minAmplitude;
+    self.amplitudeArray = [self createAmplitudeOptions];
+}
+
+- (void)setAmplitudeIncrement:(int)amplitudeIncrement {
+    _amplitudeIncrement = amplitudeIncrement;
+    self.amplitudeArray = [self createAmplitudeOptions];
 }
 
 #pragma mark - Public


### PR DESCRIPTION
Hi.
I'm using this control directly in storyboards, so I can't call the initializer with the custom values of max/min amplitude and its increment, and I need to set those later (e.g.: in the viewDidLoad)
In this PR I expose those properties, making sure in their setters to regenerate the amplitude array. I'm not sure if this is the proper way to regenerate it, but it seems to work fine. 

:+1: 
