### PR TITLE
Fix background glitch

### DIFF
--- a/Example/BAFluidView/BAViewController.m
+++ b/Example/BAFluidView/BAViewController.m
@@ -87,6 +87,28 @@
                                    selector:@selector(showSwipeForNextExampleLabel)
                                    userInfo:nil
                                     repeats:YES];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(stopAnimation)
+                                                 name:UIApplicationWillResignActiveNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(startAnimation)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+}
+
+- (void)stopAnimation {
+    if ([self.exampleContainerView isKindOfClass:[BAFluidView class]]) {
+        [(BAFluidView *)self.exampleContainerView stopAnimation];
+    }
+}
+
+- (void)startAnimation {
+    if ([self.exampleContainerView isKindOfClass:[BAFluidView class]]) {
+        [(BAFluidView *)self.exampleContainerView startAnimation];
+    }
 }
 
 - (void)viewDidLayoutSubviews {

--- a/Pod/Classes/BAFluidView.h
+++ b/Pod/Classes/BAFluidView.h
@@ -56,6 +56,16 @@ Changes the fill color of the wave animation
 @property(assign,nonatomic) NSNumber *startElavation;
 
 /**
+ Changes the maximum wave crest
+ */
+@property (assign,nonatomic) int maxAmplitude;
+
+/**
+ Changes the minimum wave crest
+ */
+@property (assign,nonatomic) int minAmplitude;
+
+/**
  Returns an object that can create the fluid animation with the given wave properties. This init function lets you adjust the wave crest properties.
  
  @param aRect

--- a/Pod/Classes/BAFluidView.h
+++ b/Pod/Classes/BAFluidView.h
@@ -131,9 +131,13 @@ This method lets you choose to what level you want the fluidVIew to increase or 
 - (void)startAnimation;
 
 /**
+ This methods stops all the desired animations
+ */
+- (void)stopAnimation;
+
+/**
 This method can set all the default values prior to start of animation
  */
 - (void)initialize;
-
 
 @end

--- a/Pod/Classes/BAFluidView.h
+++ b/Pod/Classes/BAFluidView.h
@@ -56,6 +56,11 @@ Changes the fill color of the wave animation
 @property(assign,nonatomic) NSNumber *startElavation;
 
 /**
+ Changes the interval between Max and Min the random function will use
+ */
+@property (assign,nonatomic) int amplitudeIncrement;
+
+/**
  Changes the maximum wave crest
  */
 @property (assign,nonatomic) int maxAmplitude;

--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -32,8 +32,6 @@
 @property (strong,nonatomic) NSArray *amplitudeArray;
 @property (assign,nonatomic) int startingAmplitude;
 @property (assign,nonatomic) int amplitudeIncrement;
-@property (assign,nonatomic) int maxAmplitude;
-@property (assign,nonatomic) int minAmplitude;
 
 @property (strong,nonatomic) NSNumber* startElevation;
 @property (strong,nonatomic) NSNumber* fillLevel;

--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -31,7 +31,6 @@
 
 @property (strong,nonatomic) NSArray *amplitudeArray;
 @property (assign,nonatomic) int startingAmplitude;
-@property (assign,nonatomic) int amplitudeIncrement;
 
 @property (strong,nonatomic) NSNumber* startElevation;
 @property (strong,nonatomic) NSNumber* fillLevel;
@@ -152,7 +151,21 @@
     CGRect frame = self.lineLayer.frame;
     frame.origin.y = CGRectGetHeight(self.rootView.frame)*((1-[_startElavation floatValue]));
     self.lineLayer.frame = frame;
-    
+}
+
+- (void)setMaxAmplitude:(int)maxAmplitude {
+    _maxAmplitude = maxAmplitude;
+    self.amplitudeArray = [self createAmplitudeOptions];
+}
+
+- (void)setMinAmplitude:(int)minAmplitude {
+    _minAmplitude = minAmplitude;
+    self.amplitudeArray = [self createAmplitudeOptions];
+}
+
+- (void)setAmplitudeIncrement:(int)amplitudeIncrement {
+    _amplitudeIncrement = amplitudeIncrement;
+    self.amplitudeArray = [self createAmplitudeOptions];
 }
 
 #pragma mark - Public


### PR DESCRIPTION
This should fix #14 although it might need to be documented in the readme since this happens also when you have a fluid view in a tab. Once the user switches tabs and goes back to the one with the fluid we should stop and restart the animation as well. In this case the `UIApplicationWillResignActiveNotification` and `UIApplicationDidBecomeActiveNotification` won't do the trick and we need to use for instance viewWillAppear/Disappear.  

What do you think?
