### PR TITLE
[Fix] Fixed getting index for amplitude array.

### DIFF
--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -544,7 +544,7 @@ NSString * const kBAFluidViewCMMotionUpdate = @"BAFluidViewCMMotionUpdate";
     startPoint = CGPointMake(0,0);
     
     //grabbing random amplitude to shrink/grow to
-    NSNumber *index = [NSNumber numberWithInt:arc4random_uniform(7)];
+    NSNumber *index = [NSNumber numberWithInt:arc4random_uniform((u_int32_t)self.amplitudeArray.count)];
     
     int finalAmplitude = [[self.amplitudeArray objectAtIndex:index.intValue] intValue];
     NSMutableArray *values = [[NSMutableArray alloc] init];


### PR DESCRIPTION
 It was crash due to going beyond the array bounds if there were less than 7 members in self.amplitudeArray
