### PR TITLE
More accurate calculations for gravity

### DIFF
--- a/Pod/Classes/BAFluidView.m
+++ b/Pod/Classes/BAFluidView.m
@@ -464,8 +464,7 @@ NSString * const kBAFluidViewCMMotionUpdate = @"BAFluidViewCMMotionUpdate";
     //computing roll leads to a more stable value
     //http://stackoverflow.com/q/19239482/1408431
     CMDeviceMotion *data = [[note userInfo] valueForKey:@"data"];
-    CMQuaternion quat = data.attitude.quaternion;
-    CGFloat roll = atan2(2*(quat.y*quat.w - quat.x*quat.z), 1 - 2*quat.y*quat.y - 2*quat.z*quat.z);
+    CGFloat roll = atan2(data.gravity.y, data.gravity.x) + (90 * M_PI) / 180;
     
     //limiting tilt
     if((roll + self.rollOrientationAdjustment)< -1){


### PR DESCRIPTION
Your original code takes the rotation the phone is in when the app is first opened to be the direction of gravity, this means if the app is opened when the phone is upside down (for example), the fluid will always be stuck to top of the app. This change will take the absolute value for gravity to be down instead meaning the fluid will always obey gravity correctly.